### PR TITLE
StaffControler - Create/Edit

### DIFF
--- a/WMBA-4/WMBA-4/Views/Staff/Create.cshtml
+++ b/WMBA-4/WMBA-4/Views/Staff/Create.cshtml
@@ -61,7 +61,7 @@
                         {
                             <div class="mb-1">
                                 <div class="form-check form-switch">
-                                    <input class="form-check-input" type="checkbox"
+                                    <input class="form-check-input" type="radio"
                                            id="@role.RoleName-CheckBox"
                                            name="selectedRoles"
                                            value="@role.RoleName"

--- a/WMBA-4/WMBA-4/Views/Staff/Edit.cshtml
+++ b/WMBA-4/WMBA-4/Views/Staff/Edit.cshtml
@@ -62,10 +62,10 @@
                         {
                             <div class="mb-1">
                                 <div class="form-check form-switch">
-                                    <input class="form-check-input" type="checkbox"
-                                           id="@role.RoleName-CheckBox"
-                                           name="selectedRoles"
-                                           value="@role.RoleName"
+                                    <input class="form-check-input" type="radio"
+                                        id="@role.RoleName-CheckBox"
+                                        name="selectedRoles"
+                                        value="@role.RoleName"
                                     @(Html.Raw(role.Assigned ? "checked=\"checked\"" : "")) />
                                     <label class="form-check-label" for="@role.RoleName-CheckBox">@role.RoleName</label>
                                 </div>


### PR DESCRIPTION
StaffControler - Create/Edit 
	Modify role assignment functionality to allow only one role per user, using radio buttons instead of checkboxes or toggles.

StaffControler - Edit
	Administrators should not be able to change their own roles. Only administrators can change roles, but an administrator cannot modify or delete their own role.
