### PR TITLE
StaffControler - Create/Edit

### DIFF
--- a/WMBA-4/WMBA-4/Views/Staff/Index.cshtml
+++ b/WMBA-4/WMBA-4/Views/Staff/Index.cshtml
@@ -46,20 +46,20 @@
                             @:  @r <br />
                         }
                     }
-                </td>
+                </td>                
                 
-                
-                @if(!item.Roles.Contains("Admin"))
+                <td class="text-center">
+                @if (!item.Roles.Contains("Admin"))
                 {
-                    <td class="text-center">
-                        <a asp-action="Edit" asp-route-id="@item.ID" class="btn btn-sm btn-outline-primary"
-                        role="button" data-bs-toggle="tooltip" title="Edit @ViewData["ControllerFriendlyName"]">
-                            &#x270E; Edit
-                        </a>
-                    </td>
+                    <a asp-action="Edit" asp-route-id="@item.ID" class="btn btn-sm btn-outline-primary"
+                    role="button" data-bs-toggle="tooltip" title="Edit @ViewData["ControllerFriendlyName"]">
+                        &#x270E; Edit
+                    </a>
                 }
+                </td>               
                 
             </tr>
+
         }
     </tbody>
 </table>

--- a/WMBA-4/WMBA-4/Views/Staff/Index.cshtml
+++ b/WMBA-4/WMBA-4/Views/Staff/Index.cshtml
@@ -47,14 +47,18 @@
                         }
                     }
                 </td>
-                                <td class="text-center">
-                    <a asp-action="Edit" asp-route-id="@item.ID" class="btn btn-sm btn-outline-primary"
-                       role="button" data-bs-toggle="tooltip" title="Edit @ViewData["ControllerFriendlyName"]">
-                        &#x270E; Edit
-                    </a>
-                    
-                </td>
-                                
+                
+                
+                @if(!item.Roles.Contains("Admin"))
+                {
+                    <td class="text-center">
+                        <a asp-action="Edit" asp-route-id="@item.ID" class="btn btn-sm btn-outline-primary"
+                        role="button" data-bs-toggle="tooltip" title="Edit @ViewData["ControllerFriendlyName"]">
+                            &#x270E; Edit
+                        </a>
+                    </td>
+                }
+                
             </tr>
         }
     </tbody>


### PR DESCRIPTION
StaffControler - Create/Edit 
 Modify role assignment functionality to allow only one role per user, using radio buttons instead of checkboxes or toggles.

StaffControler - Edit
 Administrators should not be able to change their own roles. Only administrators can change roles, but an administrator cannot modify or delete their own role.